### PR TITLE
Disable sendfile in nginx.conf

### DIFF
--- a/proxy.nginx.conf
+++ b/proxy.nginx.conf
@@ -19,7 +19,7 @@ http {
 
   access_log  /var/log/nginx/access.log  main;
 
-  sendfile      on;
+  sendfile      off;
 
   keepalive_timeout  65;
 


### PR DESCRIPTION
Using the docker-compose setup on OSX with docker-machine and without dinghy or similar, we ran into an issue where nginx was caching resources. Disabling sendfile fixes this. 