### PR TITLE
Adjust dialog alert call

### DIFF
--- a/src/main/js/components/ExamplePluginComponent.jsx
+++ b/src/main/js/components/ExamplePluginComponent.jsx
@@ -30,10 +30,10 @@ var ExamplePluginComponent = React.createClass({
   handleClick: function (e) {
     e.stopPropagation();
 
-    PluginHelper.callAction(PluginActions.DIALOG_ALERT, {
+    PluginHelper.callAction(PluginActions.DIALOG_ALERT, [{
       title: "Hello world",
       message: "Hi, Plugin speaking here."
-    });
+    }]);
   },
 
   render: function () {


### PR DESCRIPTION
Change the dialog alert action call to pass an arguments array instead of simply passing the properties object.

/cc @daltonmatos